### PR TITLE
Backport: Add header guards and clean up Button self-qualification (aeos)

### DIFF
--- a/Helios/Button.cpp
+++ b/Helios/Button.cpp
@@ -85,7 +85,6 @@ void Button::enableWake()
 ISR(PCINT0_vect) {
   PCMSK &= ~(1 << PCINT3);
   GIMSK &= ~(1 << PCIE);
-  Helios::wakeup();
 }
 #endif
 
@@ -108,8 +107,8 @@ bool Button::check()
 // detect if the button is being held for a long hold (past long click)
 bool Button::holdPressing()
 {
-  uint16_t holDur = (uint16_t)(Button::holdDuration());
-  if (holDur > HOLD_CLICK_START && holDur <= HOLD_CLICK_END && Button::isPressed()) {
+  uint16_t holDur = (uint16_t)holdDuration();
+  if (holDur > HOLD_CLICK_START && holDur <= HOLD_CLICK_END && isPressed()) {
     return true;
   }
   return false;
@@ -138,10 +137,11 @@ void Button::update()
       m_releaseCount++;
     }
   }
+  const uint32_t curtime = Time::getCurtime();
   if (m_isPressed) {
-    m_holdDuration = (Time::getCurtime() >= m_pressTime) ? (uint32_t)(Time::getCurtime() - m_pressTime) : 0;
+    m_holdDuration = (curtime >= m_pressTime) ? (uint32_t)(curtime - m_pressTime) : 0;
   } else {
-    m_releaseDuration = (Time::getCurtime() >= m_releaseTime) ? (uint32_t)(Time::getCurtime() - m_releaseTime) : 0;
+    m_releaseDuration = (curtime >= m_releaseTime) ? (uint32_t)(curtime - m_releaseTime) : 0;
   }
   m_shortClick = (m_newRelease && (m_holdDuration <= SHORT_CLICK_THRESHOLD));
   m_longClick = (m_newRelease && (m_holdDuration > SHORT_CLICK_THRESHOLD) && (m_holdDuration < HOLD_CLICK_START));
@@ -171,13 +171,13 @@ bool Button::processPreInput()
   char command = m_inputQueue.front();
   switch (command) {
   case 'p': // press
-    Button::doPress();
+    doPress();
     break;
   case 'r': // release
-    Button::doRelease();
+    doRelease();
     break;
   case 't': // toggle
-    Button::doToggle();
+    doToggle();
     break;
   case 'q': // quit
     Helios::terminate();
@@ -205,10 +205,10 @@ bool Button::processPostInput()
   char command = m_inputQueue.front();
   switch (command) {
   case 'c': // click button
-    Button::doShortClick();
+    doShortClick();
     break;
   case 'l': // long click button
-    Button::doLongClick();
+    doLongClick();
     break;
   default:
     // should never happen

--- a/Helios/Button.h
+++ b/Helios/Button.h
@@ -1,3 +1,6 @@
+#ifndef BUTTON_H
+#define BUTTON_H
+
 #include <stdint.h>
 
 #ifdef HELIOS_CLI
@@ -117,3 +120,5 @@ private:
   static bool m_enableWake;
 #endif
 };
+
+#endif // BUTTON_H

--- a/Helios/ColorConstants.h
+++ b/Helios/ColorConstants.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COLOR_CONSTANTS_H
+#define COLOR_CONSTANTS_H
 
 #include <inttypes.h>
 
@@ -166,3 +167,5 @@
 #define RGB_PINK_SAT_LOWEST          (uint32_t)0xE87DFF // 232, 125, 255
 #define RGB_HOT_PINK_SAT_LOWEST      (uint32_t)0xFF7DD8 // 255, 125, 216
 #define RGB_MAGENTA_SAT_LOWEST       (uint32_t)0xFF7D9B // 255, 125, 155
+
+#endif // COLOR_CONSTANTS_H

--- a/Helios/Colortypes.h
+++ b/Helios/Colortypes.h
@@ -1,5 +1,5 @@
-#ifndef COLOR_H
-#define COLOR_H
+#ifndef COLORTYPES_H
+#define COLORTYPES_H
 
 #include <inttypes.h>
 

--- a/Helios/Helios.h
+++ b/Helios/Helios.h
@@ -1,3 +1,6 @@
+#ifndef HELIOS_H
+#define HELIOS_H
+
 #include <stdint.h>
 
 #include "HeliosConfig.h"
@@ -120,3 +123,5 @@ private:
   static bool sleeping;  // Only used in CLI mode
 #endif
 };
+
+#endif // HELIOS_H

--- a/Helios/Led.cpp
+++ b/Helios/Led.cpp
@@ -67,6 +67,11 @@ void Led::adjustBrightness(uint8_t fadeBy)
   m_ledColor.adjustBrightness(fadeBy);
 }
 
+void Led::setBrightness(uint8_t brightness)
+{
+  m_brightness = brightness;
+}
+
 void Led::strobe(uint16_t on_time, uint16_t off_time, RGBColor off_col, RGBColor on_col)
 {
   set(((Time::getCurtime() % (on_time + off_time)) > on_time) ? off_col : on_col);

--- a/Helios/Led.h
+++ b/Helios/Led.h
@@ -42,7 +42,7 @@ public:
 
   // global brightness
   static uint8_t getBrightness() { return m_brightness; }
-  static void setBrightness(uint8_t brightness) { m_brightness = brightness; }
+  static void setBrightness(uint8_t brightness);
 
   // actually update the LEDs and show the changes
   static void update();

--- a/Helios/Pattern.cpp
+++ b/Helios/Pattern.cpp
@@ -1,6 +1,5 @@
 #include "Pattern.h"
 
-//#include "../Patterns/PatternBuilder.h"
 #include "TimeControl.h"
 #include "Colorset.h"
 

--- a/Helios/Random.h
+++ b/Helios/Random.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RANDOM_H
+#define RANDOM_H
 
 #include <stdint.h>
 
@@ -18,3 +19,4 @@ private:
   uint32_t m_seed;
 };
 
+#endif // RANDOM_H

--- a/Helios/TimeControl.cpp
+++ b/Helios/TimeControl.cpp
@@ -1,10 +1,7 @@
 #include "TimeControl.h"
-
-#include <math.h>
-
 #include "Timings.h"
 
-#include "Led.h"
+#include <math.h>
 
 #ifdef HELIOS_EMBEDDED
 #include <avr/sleep.h>

--- a/Helios/TimeControl.h
+++ b/Helios/TimeControl.h
@@ -11,27 +11,24 @@
 
 class Time
 {
-  // private unimplemented constructor
-  Time();
-
 public:
-  // opting for static class here because there should only ever be one
-  // Settings control object and I don't like singletons
+  // initialization and cleanup of time system
   static bool init();
   static void cleanup();
 
   // tick the clock forward to millis()
   static void tickClock();
 
-  // get the current tick, offset by any active simulation (simulation only exists in vortexlib)
-  // Exposing this in the header seems to save on space a non negligible amount, it is used a lot
-  // and exposing in the header probably allows the compiler to optimize away repititive calls
+  // get the current engine tick number (1 tick per millisecond)
   static uint32_t getCurtime() { return m_curTick; }
 
-  // Current microseconds since startup, only use this for things like measuring rapid data transfer timings.
-  // If you just need to perform regular time checks for a pattern or some logic then use getCurtime() and measure
-  // time in ticks, use the SEC_TO_TICKS() or MS_TO_TICKS() macros to convert timings to measures of ticks for
-  // purpose of comparing against getCurtime()
+  // Current microseconds since startup *DO NOT USE USING THIS API!*
+  //
+  // If you just need to perform regular time checks for a pattern or some
+  // logic then use getCurtime() and measure time in ticks. Use the macros
+  // SEC_TO_TICKS() or MS_TO_TICKS() to convert timings to measures of ticks
+  // then compare against getCurtime(). The engine thinks in ticks, only the
+  // timestep system sees microseconds, purely to maintain a stable tickrate.
   static uint32_t microseconds();
 
   // delay for some number of microseconds or milliseconds, these are bad


### PR DESCRIPTION
## Summary

Port of master PR #152 cleanup changes to the `aeos` branch. These are the same underlying API files so the cleanups apply identically.

- Add proper `#ifndef`/`#define` header guards to `Button.h`, `Helios.h`, `ColorConstants.h`, and `Random.h` (replacing `#pragma once` where used)
- Rename `Colortypes.h` guard from `COLOR_H` → `COLORTYPES_H` to match the filename
- Remove `Helios::wakeup()` from the embedded ISR (not used on embedded, was never needed)
- Remove unnecessary `Button::` self-qualification on static method calls within `Button.cpp` (`holdPressing`, `processPreInput`, `processPostInput`)
- Extract repeated `Time::getCurtime()` calls into a `const` local variable in `Button::update()`
- Move `Led::setBrightness()` out of inline in the header into `Led.cpp`
- Remove commented-out dead include from `Pattern.cpp`
- Remove unused `Led.h` include from `TimeControl.cpp`
- Update `TimeControl.h` comments for clarity (remove stale singleton comment, improve API docs)

## Test plan
- [ ] CLI builds cleanly
- [ ] Embedded builds cleanly

Made with [Cursor](https://cursor.com)