### PR TITLE
Backport: Add header guards and clean up Button/TimeControl (master-c)

### DIFF
--- a/Helios/Button.cpp
+++ b/Helios/Button.cpp
@@ -103,7 +103,6 @@ void button_enable_wake(void)
 ISR(PCINT0_vect) {
   PCMSK &= ~(1 << PCINT3);
   GIMSK &= ~(1 << PCIE);
-  helios_wakeup();
 }
 #endif
 
@@ -158,10 +157,11 @@ void button_update(void)
       m_releaseCount++;
     }
   }
+  const uint32_t curtime = time_get_current_time();
   if (m_isPressed) {
-    m_holdDuration = (time_get_current_time() >= m_pressTime) ? (uint32_t)(time_get_current_time() - m_pressTime) : 0;
+    m_holdDuration = (curtime >= m_pressTime) ? (uint32_t)(curtime - m_pressTime) : 0;
   } else {
-    m_releaseDuration = (time_get_current_time() >= m_releaseTime) ? (uint32_t)(time_get_current_time() - m_releaseTime) : 0;
+    m_releaseDuration = (curtime >= m_releaseTime) ? (uint32_t)(curtime - m_releaseTime) : 0;
   }
   m_shortClick = (m_newRelease && (m_holdDuration <= SHORT_CLICK_THRESHOLD));
   m_longClick = (m_newRelease && (m_holdDuration > SHORT_CLICK_THRESHOLD) && (m_holdDuration < HOLD_CLICK_START));

--- a/Helios/ColorConstants.h
+++ b/Helios/ColorConstants.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef COLOR_CONSTANTS_H
+#define COLOR_CONSTANTS_H
 
 #include <inttypes.h>
 
@@ -159,3 +160,5 @@
 #define RGB_PINK_SAT_LOWEST          (uint32_t)0xE87DFF // 232, 125, 255
 #define RGB_HOT_PINK_SAT_LOWEST      (uint32_t)0xFF7DD8 // 255, 125, 216
 #define RGB_MAGENTA_SAT_LOWEST       (uint32_t)0xFF7D9B // 255, 125, 155
+
+#endif // COLOR_CONSTANTS_H

--- a/Helios/Colortypes.h
+++ b/Helios/Colortypes.h
@@ -1,5 +1,5 @@
-#ifndef COLOR_H
-#define COLOR_H
+#ifndef COLORTYPES_H
+#define COLORTYPES_H
 
 #include <inttypes.h>
 

--- a/Helios/TimeControl.cpp
+++ b/Helios/TimeControl.cpp
@@ -4,12 +4,9 @@
 #endif
 
 #include "TimeControl.h"
-
-#include <math.h>
-
 #include "Timings.h"
 
-#include "Led.h"
+#include <math.h>
 
 #ifdef HELIOS_EMBEDDED
 #include <avr/sleep.h>

--- a/Helios/TimeControl.h
+++ b/Helios/TimeControl.h
@@ -20,15 +20,17 @@ void time_cleanup(void);
 // Tick the clock forward to millis()
 void time_tick_clock(void);
 
-// Get the current tick, offset by any active simulation (simulation only exists in vortexlib)
-// Exposing this as inline or macro seems to save on space a non negligible amount, it is used a lot
-// and exposing in the header probably allows the compiler to optimize away repetitive calls
+// Get the current engine tick number (1 tick per millisecond)
 uint32_t time_get_current_time(void);
 
-// Current microseconds since startup, only use this for things like measuring rapid data transfer timings.
-// If you just need to perform regular time checks for a pattern or some logic then use time_get_current_time() and measure
-// time in ticks, use the SEC_TO_TICKS() or MS_TO_TICKS() macros to convert timings to measures of ticks for
-// purpose of comparing against time_get_current_time()
+// Current microseconds since startup *DO NOT USE THIS API!*
+//
+// If you just need to perform regular time checks for a pattern or some
+// logic then use time_get_current_time() and measure time in ticks. Use the
+// macros SEC_TO_TICKS() or MS_TO_TICKS() to convert timings to measures of
+// ticks then compare against time_get_current_time(). The engine thinks in
+// ticks, only the timestep system sees microseconds, purely to maintain a
+// stable tickrate.
 uint32_t time_microseconds(void);
 
 // Delay for some number of microseconds or milliseconds, these are bad


### PR DESCRIPTION
## Summary

Port of master PR #152 cleanup changes to the `master-c` branch (C language port). Only the changes applicable to the C codebase are included — the C branch already has proper header guards on most files, so the delta is smaller.

- Add proper `#ifndef`/`#define` guard to `ColorConstants.h` (replacing `#pragma once`)
- Rename `Colortypes.h` guard from `COLOR_H` → `COLORTYPES_H` to match the filename
- Remove `helios_wakeup()` from embedded ISR in `Button.cpp` — not needed on embedded, same as the C++ branch fix
- Extract repeated `time_get_current_time()` calls into a `const` local variable in `button_update()` for clarity
- Remove unused `Led.h` include from `TimeControl.cpp`, reorder includes to put local headers first
- Update `TimeControl.h` comments on `time_get_current_time()` and `time_microseconds()` for clarity — removes stale vortexlib reference, adds clear warning on microseconds API

## Test plan
- [ ] CLI builds cleanly
- [ ] Embedded builds cleanly

Made with [Cursor](https://cursor.com)